### PR TITLE
Global parameter type registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [0.1.0] - 2023-12-29
+### Added
+
+- Global parameter type registry ([#13](https://github.com/kieran-ryan/behave-cucumber-matcher/pull/13))
+
+## 0.1.0 - 2023-12-29
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -22,27 +22,17 @@ pip install behave-cucumber-matcher
 
 ## Usage
 
-Import and patch the matcher into Behave inside `environment.py` in your `features` directory.
+Import and specify the matcher inside `environment.py` of your `features` directory.
 
 ```python
-from behave.matchers import use_step_matcher, matcher_mapping
-from behave_cucumber_matcher import build_step_matcher
-from cucumber_expressions.parameter_type_registry import ParameterTypeRegistry
-
-# Initialise a Cucumber Expressions parameter registry
-parameter_registry = ParameterTypeRegistry()
-
-# Create the step matcher to pass to behave
-step_matcher = build_step_matcher(parameter_registry)
-
-# Patch the step matcher into behave
-matcher_mapping["cucumber_expressions"] = step_matcher
+from behave.matchers import use_step_matcher
+from behave_cucumber_matcher import CUCUMBER_EXPRESSIONS_MATCHER
 
 # Specify to use the Cucumber Expressions step matcher
-use_step_matcher("cucumber_expressions")
+use_step_matcher(CUCUMBER_EXPRESSIONS_MATCHER)
 ```
 
-Create a scenario inside `color.feature` in your `features` directory:
+Create a scenario inside `color.feature` of your `features` directory:
 
 ```gherkin
 Feature: Color selection
@@ -55,7 +45,7 @@ Feature: Color selection
       Then the profile colour should be "red"
 ```
 
-Create step definitions inside `color.py` in your `features/steps` directory:
+Create step definitions inside `color.py` of your `features/steps` directory:
 
 ```python
 from behave import given, then, when
@@ -124,7 +114,7 @@ For detailed usage of _behave_, see the [official documentation](https://behave.
 
 ## Acknowledgements
 
-Based on the Behave step matcher base class and built on the architecture of [cuke4behave](https://gitlab.com/cuke4behave/cuke4behave) by [Dev Kumar Gupta](https://github.com/mrkaiser), with extended type hints, a fix for detecting patterns without arguments, a default parameter type registry, additional documentation for arguments and return types and direct import of the matcher at package level rather than via its module.
+Based on the Behave step matcher base class and built on the architecture of [cuke4behave](https://gitlab.com/cuke4behave/cuke4behave) by [Dev Kumar Gupta](https://github.com/mrkaiser), with extended type hints, a fix for detecting patterns without arguments, a default parameter type registry, additional documentation for arguments and return types, direct import of the matcher at package level rather than via its module, and a global parameter type registry.
 
 ## License
 

--- a/behave_cucumber_matcher/__init__.py
+++ b/behave_cucumber_matcher/__init__.py
@@ -2,10 +2,17 @@
 """Behave step definition matcher for Cucumber Expressions."""
 
 from .__version__ import __version__
-from .matcher import CucumberExpressionMatcher, build_step_matcher
+from .matcher import (
+    CUCUMBER_EXPRESSIONS_MATCHER,
+    CucumberExpressionMatcher,
+    build_step_matcher,
+    parameter_registry,
+)
 
 __all__ = (
     "__version__",
     "build_step_matcher",
     "CucumberExpressionMatcher",
+    "CUCUMBER_EXPRESSIONS_MATCHER",
+    "parameter_registry",
 )

--- a/behave_cucumber_matcher/matcher.py
+++ b/behave_cucumber_matcher/matcher.py
@@ -3,10 +3,14 @@
 
 from typing import Any, Callable, List, Optional
 
-from behave.matchers import Matcher
+from behave.matchers import Matcher, matcher_mapping
 from behave.model_core import Argument
 from cucumber_expressions.expression import CucumberExpression
 from cucumber_expressions.parameter_type_registry import ParameterTypeRegistry
+
+CUCUMBER_EXPRESSIONS_MATCHER = "cucumber_expressions"
+
+parameter_registry = ParameterTypeRegistry()
 
 
 class CucumberExpressionMatcher(Matcher):
@@ -89,3 +93,8 @@ def build_step_matcher(
         )
 
     return step_matcher
+
+
+# Register the Cucumber Expressions step matcher with Behave
+step_matcher = build_step_matcher(parameter_registry)
+matcher_mapping[CUCUMBER_EXPRESSIONS_MATCHER] = step_matcher

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,18 +1,8 @@
 """Behave environment setup."""
 
-from behave.matchers import matcher_mapping, use_step_matcher
-from cucumber_expressions.parameter_type_registry import ParameterTypeRegistry
+from behave.matchers import use_step_matcher
 
-from behave_cucumber_matcher import build_step_matcher
-
-# Initialise a Cucumber Expressions parameter registry
-parameter_registry = ParameterTypeRegistry()
-
-# Create the step matcher to pass to behave
-step_matcher = build_step_matcher(parameter_registry)
-
-# Patch the step matcher into behave
-matcher_mapping["cucumber_expressions"] = step_matcher
+from behave_cucumber_matcher import CUCUMBER_EXPRESSIONS_MATCHER
 
 # Specify to use the Cucumber Expressions step matcher
-use_step_matcher("cucumber_expressions")
+use_step_matcher(CUCUMBER_EXPRESSIONS_MATCHER)

--- a/features/steps/color.py
+++ b/features/steps/color.py
@@ -2,7 +2,8 @@
 
 from behave import given, then, when
 from cucumber_expressions.parameter_type import ParameterType
-from environment import parameter_registry
+
+from behave_cucumber_matcher import parameter_registry
 
 # Define the parameter type
 color_parameter = ParameterType(

--- a/tests/unit/test_matcher.py
+++ b/tests/unit/test_matcher.py
@@ -1,10 +1,12 @@
 """Matcher unit tests."""
 
+import behave.matchers
 import pytest
 from behave.model_core import Argument
 from cucumber_expressions.parameter_type_registry import ParameterTypeRegistry
 
 from behave_cucumber_matcher.matcher import (
+    CUCUMBER_EXPRESSIONS_MATCHER,
     CucumberExpressionMatcher,
     build_step_matcher,
 )
@@ -82,3 +84,8 @@ def test_build_matcher_is_callable():
     matcher = build_step_matcher(registry)
     assert callable(matcher)
     assert matcher(print, "I have {int} cukes in my {word} now")
+
+
+def test_matcher_patched_into_behave():
+    """Matcher is patched into Behave step matchers."""
+    assert CUCUMBER_EXPRESSIONS_MATCHER in behave.matchers.matcher_mapping


### PR DESCRIPTION
# 🤔 What's changed?

- Patched the Cucumber Expressions Matcher into behave's matchers
- Provided a global registry

# ⚡️ What's your motivation?

- Simplify onboarding for seamless integration with Behave
- Remove dependencies on the `environment.py` module to define a registry and import it from step definitions - preventing relative import issues

🏷️ What kind of change is this?

- ⚡ New feature (non-breaking change which adds new behaviour)