### PR TITLE
Compatibility with parameter types missing defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Compatibility with parameter types missing intended defaults ([#14](https://github.com/kieran-ryan/behave-cucumber-matcher/pull/14))
+
 ## 0.2.0 - 2024-03-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ color = ParameterType(
     regexp="red|blue|yellow",
     type=str,
     transformer=lambda s: s,
-    use_for_snippets=True,
-    prefer_for_regexp_match=False,
 )
 
 # Pass the parameter type to the registry instance
@@ -113,7 +111,7 @@ For detailed usage of _behave_, see the [official documentation](https://behave.
 
 ## Acknowledgements
 
-Based on the Behave step matcher base class and built on the architecture of [cuke4behave](https://gitlab.com/cuke4behave/cuke4behave) by [Dev Kumar Gupta](https://github.com/mrkaiser), with extended type hints, a fix for detecting patterns without arguments, a default parameter type registry, additional documentation for arguments and return types, direct import of the matcher at package level rather than via its module, and a global parameter type registry.
+Based on the Behave step matcher base class and built on the architecture of [cuke4behave](https://gitlab.com/cuke4behave/cuke4behave) by [Dev Kumar Gupta](https://github.com/mrkaiser), with extended type hints, a fix for detecting patterns without arguments, a default parameter type registry, additional documentation for arguments and return types, direct import of the matcher at package level rather than via its module, backwards compatibility with Cucumber Expressions missing parameter type defaults, and a global parameter type registry.
 
 ## License
 

--- a/behave_cucumber_matcher/matcher.py
+++ b/behave_cucumber_matcher/matcher.py
@@ -3,6 +3,7 @@
 
 from typing import Any, Callable, List, Optional
 
+import cucumber_expressions.parameter_type
 from behave.matchers import Matcher, matcher_mapping
 from behave.model_core import Argument
 from cucumber_expressions.expression import CucumberExpression
@@ -11,6 +12,29 @@ from cucumber_expressions.parameter_type_registry import ParameterTypeRegistry
 CUCUMBER_EXPRESSIONS_MATCHER = "cucumber_expressions"
 
 parameter_registry = ParameterTypeRegistry()
+
+
+class ParameterTypeOverrides(cucumber_expressions.parameter_type.ParameterType):
+    """Matcher compatibility for Cucumber Expressions parameter types."""
+
+    def __init__(  # noqa: D107
+        self,
+        *args,
+        # Fixes missing defaults in Cucumber Expressions below 17.0.2
+        # See https://github.com/cucumber/cucumber-expressions/pull/259
+        use_for_snippets: bool = True,
+        prefer_for_regexp_match: bool = False,
+        **kwargs,
+    ):
+        super().__init__(
+            *args,
+            use_for_snippets=use_for_snippets,
+            prefer_for_regexp_match=prefer_for_regexp_match,
+            **kwargs,
+        )
+
+
+cucumber_expressions.parameter_type.ParameterType = ParameterTypeOverrides
 
 
 class CucumberExpressionMatcher(Matcher):

--- a/features/steps/color.py
+++ b/features/steps/color.py
@@ -11,8 +11,6 @@ color_parameter = ParameterType(
     regexp="red|blue|yellow",
     type=str,
     transformer=lambda s: s,
-    use_for_snippets=True,
-    prefer_for_regexp_match=False,
 )
 
 # Pass the parameter type to the registry instance

--- a/tests/unit/test_matcher.py
+++ b/tests/unit/test_matcher.py
@@ -3,6 +3,7 @@
 import behave.matchers
 import pytest
 from behave.model_core import Argument
+from cucumber_expressions.parameter_type import ParameterType
 from cucumber_expressions.parameter_type_registry import ParameterTypeRegistry
 
 from behave_cucumber_matcher.matcher import (
@@ -89,3 +90,18 @@ def test_build_matcher_is_callable():
 def test_matcher_patched_into_behave():
     """Matcher is patched into Behave step matchers."""
     assert CUCUMBER_EXPRESSIONS_MATCHER in behave.matchers.matcher_mapping
+
+
+def test_no_exception_without_parameter_type_defaults():
+    """Compatible with earlier Cucumber Expressions versions.
+
+    Cucumber Expressions below 17.0.2 do not set expected defaults
+    for `use_for_snippets` and `prefer_for_regexp_match` in the
+    parameter type.
+    """
+    ParameterType(
+        name="color",
+        regexp="red|blue|yellow",
+        type=str,
+        transformer=lambda s: s,
+    )


### PR DESCRIPTION
# 🤔 What's changed?

- Patch Cucumber Expressions Parameter Type defaults

# ⚡️ What's your motivation?

- Backwards compatibility with Cucumber Expressions below 17.0.2 which are [missing intended parameter type defaults](https://github.com/cucumber/cucumber-expressions/pull/259)

🏷️ What kind of change is this?

- ⚡ New feature (non-breaking change which adds new behaviour)