### PR TITLE
Optional transformer argument for parameter types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- Compatibility with parameter types missing transformer default ([#16](https://github.com/kieran-ryan/behave-cucumber-matcher/pull/16))
+
 ## 0.3.0 - 2024-03-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ color = ParameterType(
     name="color",
     regexp="red|blue|yellow",
     type=str,
-    transformer=lambda s: s,
 )
 
 # Pass the parameter type to the registry instance

--- a/behave_cucumber_matcher/matcher.py
+++ b/behave_cucumber_matcher/matcher.py
@@ -20,14 +20,20 @@ class ParameterTypeOverrides(cucumber_expressions.parameter_type.ParameterType):
     def __init__(  # noqa: D107
         self,
         *args,
+        type: Callable,  # noqa: A002
+        # Fixes missing defaults in Cucumber Expressions below or equal to 17.0.2
+        transformer: Optional[Callable] = None,
         # Fixes missing defaults in Cucumber Expressions below 17.0.2
         # See https://github.com/cucumber/cucumber-expressions/pull/259
         use_for_snippets: bool = True,
         prefer_for_regexp_match: bool = False,
         **kwargs,
     ):
+        transformer = transformer or (lambda value: type(value))
         super().__init__(
             *args,
+            type=type,
+            transformer=transformer,
             use_for_snippets=use_for_snippets,
             prefer_for_regexp_match=prefer_for_regexp_match,
             **kwargs,

--- a/behave_cucumber_matcher/matcher.py
+++ b/behave_cucumber_matcher/matcher.py
@@ -20,7 +20,7 @@ class ParameterTypeOverrides(cucumber_expressions.parameter_type.ParameterType):
     def __init__(  # noqa: D107
         self,
         *args,
-        type: Callable,  # noqa: A002
+        type: Any,  # noqa: A002
         # Fixes missing defaults in Cucumber Expressions below or equal to 17.0.2
         transformer: Optional[Callable] = None,
         # Fixes missing defaults in Cucumber Expressions below 17.0.2

--- a/behave_cucumber_matcher/matcher.py
+++ b/behave_cucumber_matcher/matcher.py
@@ -22,6 +22,7 @@ class ParameterTypeOverrides(cucumber_expressions.parameter_type.ParameterType):
         *args,
         type: Any,  # noqa: A002
         # Fixes missing defaults in Cucumber Expressions below or equal to 17.0.2
+        # See https://github.com/cucumber/cucumber-expressions/pull/288
         transformer: Optional[Callable] = None,
         # Fixes missing defaults in Cucumber Expressions below 17.0.2
         # See https://github.com/cucumber/cucumber-expressions/pull/259

--- a/features/steps/color.py
+++ b/features/steps/color.py
@@ -10,7 +10,6 @@ color_parameter = ParameterType(
     name="color",
     regexp="red|blue|yellow",
     type=str,
-    transformer=lambda s: s,
 )
 
 # Pass the parameter type to the registry instance

--- a/tests/unit/test_matcher.py
+++ b/tests/unit/test_matcher.py
@@ -95,13 +95,12 @@ def test_matcher_patched_into_behave():
 def test_no_exception_without_parameter_type_defaults():
     """Compatible with earlier Cucumber Expressions versions.
 
-    Cucumber Expressions below 17.0.2 do not set expected defaults
-    for `use_for_snippets` and `prefer_for_regexp_match` in the
-    parameter type.
+    Cucumber Expressions below or equal to 17.0.2 do not set
+    expected defaults for `transformer`, `use_for_snippets`
+    and `prefer_for_regexp_match` in the parameter type.
     """
     ParameterType(
         name="color",
         regexp="red|blue|yellow",
         type=str,
-        transformer=lambda s: s,
     )


### PR DESCRIPTION
# 🤔 What's changed?

- Made the Cucumber Expressions parameter type optional

# ⚡️ What's your motivation?

- The transformer is intended to be optional - casting to the `type` by default if not explicitly specified (see cucumber/cucumber-expressions#178). Python support available through cucumber/cucumber-expressions#288.
- This improves user experience, removing a common use case to specify casting the value to a callable (the `type`) without any further transformation. This is in turn improves code quality and maintainability.

# 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)